### PR TITLE
Add initial basic ia32 kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+TARGET:=kernel32.elf kernel32.bin
+GDB:=gdb
+NASM:=nasm
+
+Q:=qemu-system-i386 -cdrom iso32.iso -s
+#DBG:=1
+ifdef DBG
+Q+=-S
+endif
+
+all: check32
+
+check32:    kernel32.elf
+	grub-file --is-x86-multiboot kernel32.elf && echo "Success!" || echo "Fail!!"
+	mkdir -p isodir/boot/grub
+	cp -f kernel32.elf isodir/boot/
+	echo 'set default="0"' > isodir/boot/grub/grub.cfg
+	echo 'set timeout=1' >> isodir/boot/grub/grub.cfg
+	echo 'menuentry "kernel32 elf" {' >> isodir/boot/grub/grub.cfg
+	echo 'multiboot /boot/kernel32.elf' >> isodir/boot/grub/grub.cfg
+	echo '}' >> isodir/boot/grub/grub.cfg
+	grub-mkrescue -o iso32.iso isodir
+	$(Q)
+
+iso32: check32
+
+kernel32.elf: boot.o kernel.o libc.o vid.o gdt.o panic.o idt.o idt_wrappers.o
+	gcc -m32 -T ia32/linker.ld -o kernel32.elf -ffreestanding -g -O0 -nostdlib $^ -lgcc
+
+db32:
+#	$(MAKE) check32 T=1 &
+	$(GDB) -ex 'set confirm off' -ex 'target remote :1234' -ex 'disp/i$$cs*16+(unsigned short)$$eip' -ex 'disp/8bx$$cs*16+(unsigned short)$$eip' -ex 'disp/x$$eax' -ex 'disp/x$$ebx' -ex 'disp/x$$cs' -ex 'disp/x$$eip' -ex 'file kernel32.elf' -ex 'b kernel_main'
+
+CFLAGS:=-m32 -std=gnu99 -ffreestanding -Wall -Wextra -Werror -Ilibc -Ikernel
+CFLAGS+=-g
+CFLAGS+=-O0
+#CFLAGS+=-O2
+kernel.o:CFLAGS+=-O2
+%.o: libc/%.c
+	gcc -c $< -o $@ $(CFLAGS)
+
+%.o: kernel/%.c
+	gcc -c $< -o $@ $(CFLAGS)
+
+%.o:    ia32/%.asm
+	$(NASM) -f elf -o $@ $<
+
+%.o:    ia32/%.S
+	gcc -m32 -c $< -o $@ $(CFLAGS) -DASSEMBLY
+
+%.bin: %.elf
+	objcopy --remove-section=.note.gnu.build-id -O binary $^ $@
+
+all: $(TARGET)
+
+clean:
+	$(RM) $(TARGET) *.o *.iso
+
+clobber: clean
+	$(RM) -Rf isodir

--- a/ia32/boot.S
+++ b/ia32/boot.S
@@ -1,0 +1,140 @@
+.code32
+/* Declare constants for the multiboot header. */
+.set ALIGN,    1<<0             /* align loaded modules on page boundaries */
+.set MEMINFO,  1<<1             /* provide memory map */
+.set FLAGS,    ALIGN | MEMINFO  /* this is the Multiboot 'flag' field */
+.set MAGIC,    0x1BADB002       /* 'magic number' lets bootloader find the header */
+.set CHECKSUM, -(MAGIC + FLAGS) /* checksum of above, to prove we are multiboot */
+ 
+/* 
+Declare a multiboot header that marks the program as a kernel. These are magic
+values that are documented in the multiboot standard. The bootloader will
+search for this signature in the first 8 KiB of the kernel file, aligned at a
+32-bit boundary. The signature is in its own section so the header can be
+forced to be within the first 8 KiB of the kernel file.
+*/
+.section .multiboot
+.align 4
+.long MAGIC
+.long FLAGS
+.long CHECKSUM
+ 
+/*
+The multiboot standard does not define the value of the stack pointer register
+(esp) and it is up to the kernel to provide a stack. This allocates room for a
+small stack by creating a symbol at the bottom of it, then allocating 16384
+bytes for it, and finally creating a symbol at the top. The stack grows
+downwards on x86. The stack is in its own section so it can be marked nobits,
+which means the kernel file is smaller because it does not contain an
+uninitialized stack. The stack on x86 must be 16-byte aligned according to the
+System V ABI standard and de-facto extensions. The compiler will assume the
+stack is properly aligned and failure to align the stack will result in
+undefined behavior.
+*/
+.section .bss
+.global stack_bottom
+.global stack_top
+.align 16
+stack_bottom:
+.skip 16384 # 16 KiB
+stack_top:
+ 
+/*
+The linker script specifies _start as the entry point to the kernel and the
+bootloader will jump to this position once the kernel has been loaded. It
+doesn't make sense to return from this function as the bootloader is gone.
+*/
+.section .text
+.global _start
+.global gdt
+.type _start, @function
+_start:
+    /*
+    The bootloader has loaded us into 32-bit protected mode on a x86
+    machine. Interrupts are disabled. Paging is disabled. The processor
+    state is as defined in the multiboot standard. The kernel has full
+    control of the CPU. The kernel can only make use of hardware features
+    and any code it provides as part of itself. There's no printf
+    function, unless the kernel provides its own <stdio.h> header and a
+    printf implementation. There are no security restrictions, no
+    safeguards, no debugging mechanisms, only what the kernel provides
+    itself. It has absolute and complete power over the
+    machine.
+    */
+ 
+    /*
+    To set up a stack, we set the esp register to point to the top of the
+    stack (as it grows downwards on x86 systems). This is necessarily done
+    in assembly as languages such as C cannot function without a stack.
+    */
+    mov $stack_top, %esp
+ 
+    /*
+    This is a good place to initialize crucial processor state before the
+    high-level kernel is entered. It's best to minimize the early
+    environment where crucial features are offline. Note that the
+    processor is not fully initialized yet: Features such as floating
+    point instructions and instruction set extensions are not initialized
+    yet. The GDT should be loaded here. Paging should be enabled here.
+    C++ features such as global constructors and exceptions will require
+    runtime support to work as well.
+    */
+#if 1
+    lgdt gdt
+    mov $0x10,%ax
+    mov %ax,%ds
+    mov %ax,%es
+    mov %ax,%fs
+    mov %ax,%gs
+    mov %ax,%ss
+    ljmp $0x8,$Here32
+Here32:
+#else
+    sgdt gdt
+#endif
+
+    /*
+    Enter the high-level kernel. The ABI requires the stack is 16-byte
+    aligned at the time of the call instruction (which afterwards pushes
+    the return pointer of size 4 bytes). The stack was originally 16-byte
+    aligned above and we've pushed a multiple of 16 bytes to the
+    stack since (pushed 0 bytes so far), so the alignment has thus been
+    preserved and the call is well defined.
+    */
+    call kernel_main
+ 
+    /*
+    If the system has nothing more to do, put the computer into an
+    infinite loop. To do that:
+    1) Disable interrupts with cli (clear interrupt enable in eflags).
+       They are already disabled by the bootloader, so this is not needed.
+       Mind that you might later enable interrupts and return from
+       kernel_main (which is sort of nonsensical to do).
+    2) Wait for the next interrupt to arrive with hlt (halt instruction).
+       Since they are disabled, this will lock up the computer.
+    3) Jump to the hlt instruction if it ever wakes up due to a
+       non-maskable interrupt occurring or due to system management mode.
+    */
+    cli
+1:      hlt
+    jmp 1b
+
+gdt:
+NULL_Desc:
+.word EndGDT-gdt-1
+//.long gdt+KERNEL_ADDR
+.long gdt
+.word 0
+CS_Desc:
+.word 0xFFFF,0
+.byte 0,0x9B,0xCF,0
+DS_Desc:
+.word 0xFFFF,0
+.byte 0,0x93,0xCF,0
+EndGDT:
+
+/*
+Set the size of the _start symbol to the current location '.' minus its start.
+This is useful when debugging or when you implement call tracing.
+*/
+.size _start, . - _start

--- a/ia32/idt_wrappers.S
+++ b/ia32/idt_wrappers.S
@@ -1,0 +1,236 @@
+#include "idt.h"
+
+.extern idt_handlers
+.globl idt_wrappers
+.globl def_int_wrappers
+
+/* wrapper for exceptions without error code */
+.irp id,0,1,2,3,4,5,6,7,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31
+.p2align 2,0x90
+exc_wrapper_\id:
+					// eflags	4 4
+					// cs		4 8
+					// eip		4 12
+push $0				// error	4 16		// fake error code
+push %ebp			// ebp		4 20
+mov %esp,%ebp		// 0(ebp)=ebp 4(ebp)=error 8(ebp)=eip 12(ebp)=cs 14(ebp)=eflags
+push %edi
+push %esi
+push %edx
+push %ecx
+push %ebx
+push %eax
+push %ss
+push %ds
+push %es
+push %fs
+push %gs
+push %ebp			// provide SEH params
+push $\id
+lea idt_handlers,%edi
+call *\id*4(%edi)
+add $8,%esp			// pop id+ebp
+pop %gs
+pop %fs
+pop %es
+pop %ds
+pop %ss
+pop %eax
+pop %ebx
+pop %ecx
+pop %edx
+pop %esi
+pop %edi
+pop %ebp
+add $4,%esp		// remove fake error code
+iret
+.endr
+
+/* wrapper for exceptions with error code */
+.irp id,8
+.p2align 2,0x90
+exc_wrapper_\id:
+					// eflags	4 4
+					// cs		4 8
+					// eip		4 12
+					// error	4 16
+push %ebp			// ebp		4 20
+mov %esp,%ebp		// 0(ebp)=ebp 4(ebp)=error 8(ebp)=eip 12(ebp)=cs 14(ebp)=eflags
+push %edi
+push %esi
+push %edx
+push %ecx
+push %ebx
+push %eax
+push %ss
+push %ds
+push %es
+push %fs
+push %gs
+push %ebp			// provide SEH params
+push $\id
+lea idt_handlers,%edi
+call *\id*4(%edi)
+add $8,%esp
+pop %gs
+pop %fs
+pop %es
+pop %ds
+pop %ss
+pop %eax
+pop %ebx
+pop %ecx
+pop %edx
+pop %esi
+pop %edi
+pop %ebp
+add $4,%esp			// remove error code
+iret
+.endr
+
+/* wrapper irqs without error code */
+					// eflags	4 4
+					// cs		4 8
+					// eip		4 12
+					// $0
+					// $ebp
+.irp id,IRQ_TIMER,IRQ_KB
+.p2align 2,0x90
+irq_wrapper_\id:
+push $0
+push %ebp
+mov %esp,%ebp
+push %edi
+push %esi
+push %edx
+push %ecx
+push %ebx
+push %eax
+sub $2,%esp
+push %ss
+push %ds
+push %es
+push %fs
+push %gs
+mov $0x20,%al
+outb %al,$0x20
+push %ebp
+push $\id
+lea idt_handlers,%edi
+call *(IRQ_BASE+\id)*4(%edi)
+add $8,%esp
+pop %gs
+pop %fs
+pop %es
+pop %ds
+pop %ss
+add $2,%esp
+pop %eax
+pop %ebx
+pop %ecx
+pop %edx
+pop %esi
+pop %edi
+pop %ebp
+add $4,%esp
+iret
+.endr
+
+#if 0
+dblflt_stack0:
+.string "EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"
+dblflt_stack:
+msg:
+.string "DBLFLT@%p:%p %p"
+
+.irp id,EXCEPTION_DOUBLE
+.p2align 2,0x90
+exc_wrapper_\id:
+
+// print double fault message before infinite loop
+cli
+
+#if 1
+movl $0xCF44CF2A,0xb8000
+movl $0xCF4CCF42,0xb8004
+movl $0xCF4CCF46,0xb8008
+movl $0xCF2ACF54,0xb800c
+#elif 1
+mov %esp,%ecx
+mov (%esp),%edx
+mov 4(%esp),%ebx
+mov $dblflt_stack-4,%eax
+mov %eax,%esp
+push %ebx
+push %edx
+push %ecx
+push $msg
+call home
+push $0x0C
+call setattr
+pop %eax
+call mprintf
+pop %eax
+pop %eax
+pop %eax
+pop %eax
+push $0
+push $0
+call setcursor
+#endif
+1:
+hlt
+jmp 1b
+.endr
+#endif
+
+def_int_stack0:
+.string "EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"
+def_int_stack:
+def_int_msg:
+.string "int #%x : esp=%p : %p %p %p %p"
+.irp id,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33
+.p2align 2,0x90
+def_int_wrapper_\id:
+mov %esp,%ebp
+mov $def_int_stack-4,%esp
+push 12(%ebp)
+push 8(%ebp)
+push 4(%ebp)
+push (%ebp)
+push %ebp
+push $\id
+push $def_int_msg
+call home
+push $0x0C
+call setattr
+pop %eax
+call mprintf
+pop %eax
+pop %eax
+pop %eax
+pop %eax
+push $0
+push $0
+call setcursor
+1:
+hlt
+jmp 1b
+.endr
+
+.section .rodata
+.p2align 5,0x0
+idt_wrappers:
+.irp id,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31
+.long exc_wrapper_\id
+.endr
+
+irq_wrappers:
+.irp id,0,1
+.long irq_wrapper_\id
+.endr
+
+def_int_wrappers:
+.irp id,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33
+.long def_int_wrapper_\id
+.endr

--- a/ia32/linker.ld
+++ b/ia32/linker.ld
@@ -1,0 +1,44 @@
+/* The bootloader will look at this image and start execution at the symbol
+   designated as the entry point. */
+ENTRY(_start)
+ 
+/* Tell where the various sections of the object files will be put in the final
+   kernel image. */
+SECTIONS
+{
+    /* Begin putting sections at 1 MiB, a conventional place for kernels to be
+       loaded at by the bootloader. */
+/*    . = 0x7e00;*/
+    . = 0x10000;
+
+    /* First put the multiboot header, as it is required to be put very early
+       early in the image or the bootloader won't recognize the file format.
+       Next we'll put the .text section. */
+    .text BLOCK(4K) : ALIGN(4K)
+    {
+        *(.multiboot)
+        *(.text)
+    }
+
+    /* Read-only data. */
+    .rodata BLOCK(4K) : ALIGN(4K)
+    {
+        *(.rodata)
+    }
+
+    /* Read-write data (initialized) */
+    .data BLOCK(4K) : ALIGN(4K)
+    {
+        *(.data)
+    }
+
+    /* Read-write data (uninitialized) and stack */
+    .bss BLOCK(4K) : ALIGN(4K)
+    {
+        *(COMMON)
+        *(.bss)
+    }
+
+    /* The compiler may produce other sections, by default it will put them in
+       a segment with the same name. Simply add stuff here as needed. */
+}

--- a/kernel/gdt.c
+++ b/kernel/gdt.c
@@ -1,0 +1,131 @@
+#include "gdt.h"
+#include "libc.h"
+#include "types.h"
+
+#pragma pack(1)
+typedef struct {
+    uint16_t size;
+#ifdef _LP64
+    uint64_t offset;
+#else
+    uint32_t offset;
+#endif
+} gdtr_t;
+#pragma pack()
+
+// segment selector
+//15    3       2       1   0
+//Index         TI      RPL
+
+#pragma pack(1)
+typedef struct {
+#if 1
+    uint16_t limit;
+    uint16_t base;
+    uint8_t baseHA;
+    uint8_t acc_byte;
+    uint8_t limitH:4, flags:4;
+    uint8_t baseHB;
+#else
+    uint16_t base;
+    uint16_t limit;
+    uint8_t baseHB;
+    uint8_t flags:4, limitH:4;
+    uint8_t acc_byte;
+    uint8_t baseHA;
+#endif
+} gdt_t;
+
+#if 1
+typedef union {
+    uint64_t u;
+//    uint32_t u;
+    gdt_t g;
+} gdt_u;
+#pragma pack()
+#endif
+
+#if 0
+static uint64_t htonq(uint64_t u0) {
+    uint64_t u = 0;
+    u = (u << 8) | (u0 & 0xff);u0 >>= 8;
+    u = (u << 8) | (u0 & 0xff);u0 >>= 8;
+    u = (u << 8) | (u0 & 0xff);u0 >>= 8;
+    u = (u << 8) | (u0 & 0xff);u0 >>= 8;
+    u = (u << 8) | (u0 & 0xff);u0 >>= 8;
+    u = (u << 8) | (u0 & 0xff);u0 >>= 8;
+    u = (u << 8) | (u0 & 0xff);u0 >>= 8;
+    u = (u << 8) | (u0 & 0xff);u0 >>= 8;
+    return u;
+}
+#endif
+
+void dump_sel(uint16_t sel) {
+    printf("sel=%" PRIx16 " RPL=%d TI=%s index=%d\n", sel, sel & 3, sel & 4 ? "LDT" : "GDT", sel >> 3);
+}
+
+void dump_attr(uint16_t attr) {
+    printf("attr=%" PRIx16 " G=%d DB=%d L=%d res=%d - P=%d DPL=%d S=%d E=%d DC=%d RW=%d A=%d\n",
+        attr, (attr & 0x8000) >> 15, (attr & 0x4000) >> 14, (attr & 0x2000) >> 13, (attr & 0x1000) >> 12,
+        (attr & 0x80) >> 7, (attr & 0x60) >> 5, (attr & 0x10) >> 4, (attr & 0x8) >> 3, (attr & 0x4) >> 2, (attr & 0x2) >> 1, attr & 0x1
+    );
+}
+
+void dump_gdt_(const gdt_t *gdtp) {
+//    const gdt_u *g = (gdt_u *)gdtp;
+//        printf("%" PRIx64 "\n", g->u);
+#if 0
+//        printf("baseHB=%02" PRIx8 " ", gdtp->baseHB);
+    printf("flags=%" PRIx8 " ", gdtp->flags);
+//        printf("limitH=%" PRIx8 " ", gdtp->limitH);
+    printf("acc_byte=%02" PRIx8 " ", gdtp->acc_byte);
+//        printf("baseHA=%02" PRIx8 " ", gdtp->baseHA);
+//        printf("baseL=%04" PRIx16 " ", gdtp->base);
+//        printf("limitL=%04" PRIx16 " ", gdtp->limit);
+#endif
+#if 1
+    dump_attr((gdtp->flags << 8) | gdtp->acc_byte);
+    uint32_t base = (gdtp->baseHB << (16 + 8)) | (gdtp->baseHA << 16) | gdtp->base;
+    printf("base=%08" PRIx32 " ", base);
+    uint32_t limit = (gdtp->limitH << 16) | gdtp->limit;
+    printf("limit=%08" PRIx32 " ", limit);
+#endif
+    printf("\n");
+}
+
+void dump_gdt() {
+    extern const gdtr_t gdt;
+    const gdtr_t *gdtr = &gdt;
+    printf("%s: gdtr=%p\n", __func__, gdtr);
+    if (gdtr) {
+        int size = gdtr->size + 1;
+        gdt_t *gdtp = (gdt_t *)(uintptr_t)gdtr->offset;
+        printf("%s: size=%d\n", __func__, size);
+        printf("%s: offset=%p\n", __func__, gdtp);
+        if (gdtp) {
+            for (size_t i = 0; i < size / sizeof(gdt_t); i++) {
+//                printf("%s:  gdt#%d sizeof(gdt)=%d ptr=%p\n", __func__, i, (int)sizeof(gdt_t), gdtp);
+                dump_gdt_(gdtp++);
+            }
+        }
+    }
+
+    uint16_t cs, ds;
+    asm volatile(
+        "mov %%cs,%%ax\n"
+        "mov %%ax,%0\n"
+        : "=g"(cs)
+        :
+        : "ax"
+    );
+    asm volatile(
+        "mov %%ds,%%ax\n"
+        "mov %%ax,%0\n"
+        : "=g"(ds)
+        :
+        : "ax"
+    );
+    printf("cs=%" PRIx16 " ds=%" PRIx16 "\n", cs, ds);
+    dump_sel(cs);
+    dump_sel(ds);
+}

--- a/kernel/gdt.h
+++ b/kernel/gdt.h
@@ -1,0 +1,6 @@
+#ifndef GDT_H__
+#define GDT_H__
+
+void dump_gdt();
+
+#endif/*GDT_H__*/

--- a/kernel/idt.c
+++ b/kernel/idt.c
@@ -1,0 +1,187 @@
+#include "libc.h"
+#include "types.h"
+
+#include "ioport.h"
+#include "idt.h"
+#include "vid.h"
+
+#pragma pack(1)
+typedef struct idtr {
+    uint16_t limit;
+#ifdef _LP64
+    uint64_t base_addr;
+#else
+    uint32_t base_addr;
+#endif
+} idtr_t;
+#pragma pack()
+
+#pragma pack(1)
+typedef struct idte {
+    uint16_t offset_low;
+    uint16_t seg_sel;
+
+#ifdef _LP64
+    uint8_t ist:3;
+    uint8_t reserved:5;
+#else
+    uint8_t reserved:5;
+    uint8_t flags:3;
+#endif
+    uint8_t type:3;
+    uint8_t op_size:1;
+    uint8_t zero:1;
+    uint8_t dpl:2;
+    uint8_t present:1;
+    uint16_t offset_high;
+#ifdef _LP64
+    uint32_t offset_highbis;
+    uint32_t rsvd;
+#endif
+} idte_t;
+#pragma pack()
+
+#define IDT_NUM IDT_MAX
+static idte_t idt[IDT_NUM];
+
+extern void *idt_wrappers[IDT_NUM] asm("idt_wrappers");
+extern void *def_int_wrappers[IDT_NUM] asm("def_int_wrappers");
+
+idt_handler_t idt_handlers[IDT_NUM] asm("idt_handlers");
+
+void halt()
+{
+	asm volatile("hlt");
+}
+
+// FIXME : implement flags backup
+void disable()
+{
+	asm volatile("cli");
+}
+
+void enable()
+{
+	asm volatile("sti");
+}
+
+void idt_setup()
+{
+	idtr_t idtr;
+	
+	int i;
+	for (i = 0; i < IDT_NUM; i++)
+	{
+		idte_t *idte = &idt[i];
+		memset(idte, 0, sizeof(*idte));
+		idte->seg_sel = 0x8;
+		idte->type = 0x6;
+		idte->op_size = 1;
+		idt_set_handler(i, def_int_wrappers[i]);
+	}
+	
+	idtr.base_addr = (typeof(idtr.base_addr))idt;
+	idtr.limit = sizeof(idt) - 1;
+	
+	asm volatile(
+		"lidt %0\n\r"
+		:
+		: "m"(idtr)
+	);
+}
+
+void idt_set_handler(int num, idt_handler_t handler) {
+    idte_t *idte = &idt[num];
+    if (!handler) {
+        idte->offset_low = 0;
+        idte->offset_high = 0;
+        idte->dpl = 0;
+        idte->present = 0;
+#ifdef _LP64
+        idte->offset_highbis = 0;
+        idte->rsvd = 0;
+#endif
+    } else {
+        idte->offset_low = (typeof(idte->offset_low))((uintptr_t)handler & 0xFFFF);
+        idte->offset_high = (typeof(idte->offset_high))(((uintptr_t)handler >> 16) & 0xFFFF);
+        idte->dpl = 0;
+        idte->present = 1;
+#ifdef _LP64
+        idte->offset_highbis = (typeof(idte->offset_highbis))(((uintptr_t)handler >> 32) & 0xFFFFFFFF);
+        idte->rsvd = 0;
+#endif
+    }
+}
+
+void exception_setup()
+{
+	idt_set_handler(EXCEPTION_DOUBLE, idt_wrappers[EXCEPTION_DOUBLE]);
+}
+
+void exception_set_handler(int num, idt_handler_t handler)
+{
+	disable();
+	idt_handlers[num] = handler;
+	idt_set_handler(num, idt_wrappers[num]);
+//	enable();
+}
+
+#define MASTER 0x20
+#define SLAVE 0xa0
+void i8259_setup()
+{
+	outb(0x11, MASTER);
+	outb(0x11, SLAVE);
+
+	outb(0x20, MASTER+1);
+	outb(0x28, SLAVE+1);
+
+	outb(0x4, MASTER+1);
+	outb(0x2, SLAVE+1);
+
+	outb(0x1, MASTER+1);
+	outb(0x1, SLAVE+1);
+
+	outb(0xFB, MASTER+1);
+	outb(0xFF, SLAVE+1);
+}
+
+void i8259_enable_line(int num)
+{
+	outb(inb(MASTER+1) & ~(1 << num),MASTER+1);
+}
+
+void i8259_disable_line(int num)
+{
+	outb(inb(MASTER+1) | (1 << num),MASTER+1);
+}
+
+void irq_setup()
+{
+	i8259_setup();
+	
+	i8259_disable_line(0);
+	i8259_disable_line(1);
+}
+
+void irq_set_handler(int num, idt_handler_t handler)
+{
+	disable();
+#if 1
+	idt_handlers[IRQ_BASE + num] = handler;
+	idt_set_handler(IRQ_BASE + num, idt_wrappers[IRQ_BASE + num]);
+#endif
+	i8259_enable_line(num);
+//	enable();
+}
+
+#define MAX_FREQ 1193180
+#define TIMER0 0x40
+#define CONTROL 0x43
+void i8254_set_freq(unsigned int freq)
+{
+	unsigned int nb_tick = MAX_FREQ / freq;
+	outb(0x34, CONTROL);
+	outb(nb_tick & 0xFF, TIMER0);
+	outb((nb_tick >> 8) & 0xFF, TIMER0);
+}

--- a/kernel/idt.h
+++ b/kernel/idt.h
@@ -1,0 +1,37 @@
+#ifndef IDT_H__
+#define IDT_H__
+
+#define EXCEPTION_BASE          0
+#define EXCEPTION_DIVIDE        0
+#define EXCEPTION_SSTEP         1
+#define EXCEPTION_DOUBLE        8
+
+#define IRQ_BASE                32
+#define IRQ_TIMER               0
+#define IRQ_KB                  1
+
+//#define IDT_MAX (IRQ_BASE+IRQ_KB)
+#define IDT_MAX (256)
+
+#ifndef ASSEMBLY
+
+#include "types.h"
+
+typedef void (*idt_handler_t)(int num, void *ptr);
+
+void idt_setup(void);
+void idt_set_handler(int num, idt_handler_t);
+void exception_setup();
+void exception_set_handler(int num, idt_handler_t handler);
+void irq_setup();
+void irq_set_handler(int num, idt_handler_t);
+
+void i8254_set_freq(unsigned int freq);
+
+void halt();
+void enable();
+void disable();
+
+#endif
+
+#endif/*IDT_H__*/

--- a/kernel/ioport.h
+++ b/kernel/ioport.h
@@ -1,0 +1,22 @@
+#ifndef IOPORT_H__
+#define IOPORT_H__
+
+#define outb(value, port) \
+	asm volatile (                                          \
+	"outb %b0,%w1"                                          \
+	::"a" (value),"Nd" (port)                               \
+	)
+#define inb(port)                                               \
+	({                                                      \
+	unsigned char _v;                                       \
+	asm volatile (                                          \
+	"inb %w1,%0"                                            \
+	:"=a" (_v)                                              \
+	:"Nd" (port)                                            \
+	);                                                      \
+	_v;                                                     \
+	})
+
+#define IODELAY() asm volatile(".byte 0x90,0x90,0x90,0x90,0x90,0x90,0x90,0x90")
+
+#endif/*IOPORT_H__*/

--- a/kernel/kb.h
+++ b/kernel/kb.h
@@ -1,0 +1,172 @@
+#ifndef KB_H_
+#define KB_H_
+
+#define KB_PORT 0x60
+
+/*
+scan codes set 1
+Below are pressed scan codes
+Release codes are pressed+0x80
+Ignore extended codes ({0xe0,XX} and {0xe1,XX,YY})
+*/
+#define S_FIRST 0x01
+#define S_ESC   0x01
+#define S_1     0x02
+#define S_2     0x03
+#define S_3     0x04
+#define S_4     0x05
+#define S_5     0x06
+#define S_6     0x07
+#define S_7     0x08
+#define S_8     0x09
+#define S_9     0x0a
+#define S_0     0x0b
+#define S_MINUS 0x0c
+#define S_EQUAL 0x0d
+#define S_BACKS 0x0e
+
+#define S_TAB   0x0f
+#define S_Q     0x10
+#define S_W     0x11
+#define S_E     0x12
+//...
+
+#define S_A     0x1e
+#define S_S     0x1f
+#define S_D     0x20
+//...
+#define S_BTICK 0x29
+//...
+#define S_CAPSL 0x3a
+#define S_F1    0x3b
+#define S_F2    0x3c
+#define S_F3    0x3d
+//...
+#define S_F11   0x57
+#define S_F12   0x58
+#define S_LAST  0x58
+
+/*
+key codes are 8-bits, where high 3 bits are 'row', and 5 low bits are 'col'
+row 1: esc f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 f11 f12 prscr scrlk pause                     => 16 cols
+row 2: btick 1 2 3 4 5 6 7 8 9 0 - = back ins home pgup numlk kpdiv kpmul kpmin         => 21 cols
+row 3: tab q w e r t y u i o p [ ] enter del end pgdn kp7 kp8 kp9 kpplus                => 21 cols
+row 4: capsl a s d f g h j k l ; ' \ kp4 kp5 kp6                                        => 16 cols
+row 5: lshft < z x c v b n m , . / rshft up 1 2 3 kpent                                 => 18 cols
+row 6: lctrl lwin alt space altgr rwin menu rctrl left down right kp0 kpdot             => 13 cols
+                0bRRRCCCCC
+*/
+#define K(r,c) ((r << 5) + c)
+#define K_ESC   K(0,0)
+#define K_F1    K(0,1)
+#define K_F2    K(0,2)
+#define K_F3    K(0,3)
+#define K_F4    K(0,4)
+#define K_F5    K(0,5)
+#define K_F6    K(0,6)
+#define K_F7    K(0,7)
+#define K_F8    K(0,8)
+#define K_F9    K(0,9)
+#define K_F10   K(0,10)
+#define K_F11   K(0,11)
+#define K_F12   K(0,12)
+#define K_PRSCR K(0,13)
+#define K_SCRLK K(0,14)
+#define K_PAUSE K(0,15)
+
+#define K_BTICK K(1,0)
+#define K_1     K(1,1)
+#define K_2     K(1,2)
+#define K_3     K(1,3)
+#define K_4     K(1,4)
+#define K_5     K(1,5)
+#define K_6     K(1,6)
+#define K_7     K(1,7)
+#define K_8     K(1,8)
+#define K_9     K(1,9)
+#define K_0     K(1,10)
+#define K_MINUS K(1,11)
+#define K_EQUAL K(1,12)
+#define K_BACKS K(1,13)
+#define K_INS   K(1,14)
+#define K_HOME  K(1,15)
+#define K_PGUP  K(1,16)
+#define K_NUMLK K(1,17)
+#define K_KPDIV K(1,18)
+#define K_KPMUL K(1,19)
+#define K_KPMIN K(1,20)
+
+#define K_TAB   K(2,0)
+#define K_Q     K(2,1)
+#define K_W     K(2,2)
+#define K_E     K(2,3)
+#define K_R     K(2,4)
+#define K_T     K(2,5)
+#define K_Y     K(2,6)
+#define K_U     K(2,7)
+#define K_I     K(2,8)
+#define K_O     K(2,9)
+#define K_P     K(2,10)
+#define K_LBRAK K(2,11)
+#define K_RBRAK K(2,12)
+#define K_ENTER K(2,13)
+#define K_DELET K(2,14)
+#define K_END   K(2,15)
+#define K_PGDN  K(2,16)
+#define K_KP7   K(2,17)
+#define K_KP8   K(2,18)
+#define K_KP9   K(2,19)
+#define K_KPPLU K(2,20)
+
+#define K_CAPSL K(3,0)
+#define K_A     K(3,1)
+#define K_S     K(3,2)
+#define K_D     K(3,3)
+#define K_F     K(3,4)
+#define K_G     K(3,5)
+#define K_H     K(3,6)
+#define K_J     K(3,7)
+#define K_K     K(3,8)
+#define K_L     K(3,9)
+#define K_COL   K(3,10)
+#define K_QUOTE K(3,11)
+#define K_BSLSH K(3,12)
+#define K_KP4   K(3,13)
+#define K_KP5   K(3,14)
+#define K_KP6   K(3,15)
+
+#define K_LSHFT K(4,0)
+#define K_INF   K(4,1)
+#define K_Z     K(4,2)
+#define K_X     K(4,3)
+#define K_C     K(4,4)
+#define K_V     K(4,5)
+#define K_B     K(4,6)
+#define K_N     K(4,7)
+#define K_M     K(4,8)
+#define K_COMMA K(4,9)
+#define K_DOT   K(4,10)
+#define K_SLASH K(4,11)
+#define K_RSHFT K(4,12)
+#define K_UP    K(4,13)
+#define K_KP1   K(4,14)
+#define K_KP2   K(4,15)
+#define K_KP3   K(4,16)
+#define K_KPENT K(4,17)
+
+#define K_LCTRL K(5,0)
+#define K_LWIN  K(5,1)
+#define K_ALT   K(5,2)
+#define K_SPACE K(5,3)
+#define K_ALTGR K(5,3)
+#define K_RWIN  K(5,3)
+#define K_MENU  K(5,3)
+#define K_RCTRL K(5,3)
+#define K_LEFT  K(5,3)
+#define K_DOWN  K(5,3)
+#define K_RIGHT K(5,3)
+#define K_KP0   K(5,3)
+#define K_KPDOT K(5,3)
+//...
+
+#endif/*KB_H_*/

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -1,0 +1,120 @@
+//#include <stdbool.h>
+//#include <stddef.h>
+//#include <stdint.h>
+
+#include "libc.h"
+#include "gdt.h"
+#include "idt.h"
+#include "vid.h"
+#include "ioport.h"
+#include "kb.h"
+#include "panic.h"
+#include "types.h"
+
+#pragma pack(1)
+typedef struct {
+    uint32_t gs;
+    uint32_t fs;
+    uint32_t es;
+    uint32_t ds;
+    uint32_t ss;
+    uint16_t filler;
+    uint32_t eax;
+    uint32_t ebx;
+    uint32_t ecx;
+    uint32_t edx;
+    uint32_t esi;
+    uint32_t edi;
+} irq_regs_t;
+
+typedef struct {
+    uint32_t ebp;
+    uint32_t zero;
+    uint32_t eip;
+    uint32_t cs;
+    uint32_t eflags;
+} irq_ctx_t;
+#pragma pack()
+
+static int kbhits = 0;
+
+#define KB_SIZE 20
+static unsigned char kb_ring[KB_SIZE];
+static int kb_head = 0;
+static int kb_tail = 0;
+static void kb_handler(int id, void *ptr) {
+    id = id; ptr = ptr;
+    unsigned char byte;
+    byte = inb(KB_PORT);
+    kb_ring[kb_head % KB_SIZE] = byte;
+    kb_head = (kb_head + 1) % KB_SIZE;
+    if (kb_head == kb_tail) {
+        panic("kb_handler overflow");
+    }
+    kbhits++;
+}
+
+static int jiffies = 0;
+static void timer_handler(int id, void *ptr) {
+    irq_regs_t *regs = (irq_regs_t *)(ptr - sizeof(irq_regs_t));
+    irq_ctx_t *ctx = (irq_ctx_t *)ptr;
+    gotoxy(0, 0);
+    printf("id=%d ptr=%p eax=%08x eip=%p efl=%04x kbhits=%d jiffies=%d \n", id, ptr, regs->eax, ctx->eip, ctx->eflags, kbhits, jiffies);
+    jiffies++;
+}
+
+void schedule() {
+    enable();
+    while (1) {
+        static int count = 0;
+        for (int i = 0; i < jiffies*1+10; i++) {
+        gotoxy(0, 1);
+        printf("hi jiffies=%d count=%d\n", jiffies, count++);
+            asm volatile("hlt");
+        }
+        halt();
+    }
+}
+
+void kernel_main(void) {
+    // it seems like GRUB/multiboot doesn't zero out .bss ?
+    extern char stack_bottom[0], stack_top[0];
+    memset(stack_bottom, 0, stack_top - stack_bottom); // zero out BSS
+    console_init();
+
+    idt_setup();
+    irq_setup();
+    irq_set_handler(IRQ_TIMER, timer_handler);
+    irq_set_handler(IRQ_KB, kb_handler);
+    i8254_set_freq(1);
+#if 1
+    printf("\n\n\n");
+    printf("Hello Kernel%s!\n", sizeof(void *) == 8 ? "64" : "32");
+    uint16_t cs, ds;
+    asm volatile(
+        "mov %%cs,%%ax\n"
+        "mov %%ax,%0\n"
+        : "=g"(cs)
+        :
+        : "ax"
+    );
+    asm volatile(
+        "mov %%ds,%%ax\n"
+        "mov %%ax,%0\n"
+        : "=g"(ds)
+        :
+        : "ax"
+    );
+    printf("cs=%" PRIx16 " ds=%" PRIx16 "\n", cs, ds);
+    extern char stack_bottom[0], stack_top[0];
+    printf("stack_bottom=%p stack_top=%p\n", stack_bottom, stack_top);
+    printf("\n\n");
+#endif
+//    printf("%01x\n", 0xa);
+    dump_gdt();
+
+    schedule();
+
+    gotoxy(0, 1);
+    panic("[toto=%s dead=%" PRIx16 " ffff0=%p ac1dc0d3=%" PRIx32 " 1234=%d]", "toto", 0xdead, 0xffff0, 0xac1dc0d3, 1234);
+}

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -1,0 +1,36 @@
+#include "panic.h"
+#include "idt.h"                // enable()...
+
+#include "libc.h"
+#include "vid.h"
+
+#include <stdarg.h>
+
+void panic(const char *fmt, ...) {
+//    disable();
+    while (1) {
+    home();
+    setattr(BG_FG(BLACK, LRED));
+    puts("Kernel panic: ");
+    va_list ap;
+    va_start(ap, fmt);
+    static char buf[80];
+    memset(buf, 'X', sizeof(buf));
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+#if 1
+    puts(buf);
+#else
+    for (size_t i = 0; i < sizeof(buf); i++) {
+        char c;
+        c = buf[i] & 0xf;
+        c = c > 9 ? 'a' + c - 10 : '0' + c;
+        dputchar(c);
+        c = buf[i] >> 4;
+        c = c > 9 ? 'a' + c - 10 : '0' + c;
+        dputchar(c);
+    }
+#endif
+        halt();
+    }
+}

--- a/kernel/panic.h
+++ b/kernel/panic.h
@@ -1,0 +1,6 @@
+#ifndef PANIC_H__
+#define PANIC_H__
+
+void panic(const char *s, ...);
+
+#endif/*PANIC_H__*/

--- a/kernel/types.h
+++ b/kernel/types.h
@@ -1,0 +1,24 @@
+#ifndef TYPES_H__
+#define TYPES_H__
+
+#ifdef _LP64
+typedef unsigned long uint64_t;
+typedef unsigned int uint32_t;
+#define PRIx64 "lx"
+#define PRIx32 "x"
+#else
+typedef unsigned long long uint64_t;
+typedef unsigned long uint32_t;
+#define PRIx64 "llx"
+#define PRIx32 "lx"
+#endif
+#define PRIx8 "x"
+#define PRIx16 "x"
+
+typedef unsigned short uint16_t;
+typedef unsigned char uint8_t;
+
+typedef unsigned long uintptr_t;
+typedef unsigned long size_t;
+
+#endif/*TYPES_H__*/

--- a/kernel/vid.c
+++ b/kernel/vid.c
@@ -1,0 +1,118 @@
+#include "libc.h"
+
+#include "vid.h"
+#include "ioport.h"
+
+static int col = 0;
+static int row = 0;
+static unsigned char attr = 0;
+
+void setattr(int _attr) {
+    attr = _attr;
+}
+
+int getattr() {
+    return attr;
+}
+
+void home() {
+    gotoxy(0, 0);
+}
+
+void gotoxy(int x, int y) {
+    col = x;
+    row = y;
+}
+
+void console_init() {
+    attr = DEFAULT_ATTR;
+    home();
+//    cls();
+}
+
+void cls() {
+#if 0
+    // problem: cells with 0x00 as attr do not display the cursor
+    // and using 0x20 instaead displays some green background
+    memset((void *)0xb8000, 0, MAX_ROW * MAX_COL * 2);
+#else
+    // slow, but works, honoring the attr
+    unsigned short *mem = (void *)0xb8000;
+    for (int row = 0; row < MAX_ROW; row++) {
+        for (int col = 0; col < MAX_COL; col++) {
+            mem[MAX_COL * row + col] = (attr << 8) | 0x00;
+        }
+    }
+#endif
+}
+
+int dputchar(int c) {
+    unsigned char *ptr = (void *)0xB8000;
+
+    int skip = 0;
+
+    if ((c == '\n') || (c =='\r')) {
+        col = 0;
+        if (c == '\n')
+        if (row < MAX_ROW) {
+            row++;
+        }
+        skip = 1;
+    }
+    if (!skip) {
+        if (col >= MAX_COL) {
+            col = 0;
+            row++;
+        }
+        ptr[(row * 80 + col) * 2] = c;
+        ptr[(row * 80 + col) * 2 + 1] = attr;
+        if (col < MAX_COL)
+            col++;
+    }
+
+    return 0;
+}
+
+void dputs(const char *s) {
+    unsigned char *ptr = (void *)0xB8000;
+
+    if (s)
+    while (*s) {
+        int skip = 0;
+
+        if (*s == '\n') {
+            if (row < MAX_ROW) {
+                col = 0;
+                row++;
+            }
+            skip = 1;
+        }
+        if (!skip) {
+            if (col >= MAX_COL) {
+                col = 0;
+                row++;
+            }
+            ptr[(row * 80 + col) * 2] = *s;
+            ptr[(row * 80 + col) * 2 + 1] = attr;
+            if (col < MAX_COL) {
+                col++;
+            }
+        }
+        s++;
+    }
+}
+
+void setcursor(int x, int y) {
+    int loc;
+    unsigned char byte;
+
+    loc = y * 80 + x;
+    outb(0xf, 0x3d4);
+    IODELAY();
+    byte = loc & 0xFF;
+    outb(byte, 0x3d5);
+    outb(0xe, 0x3d4);
+    IODELAY();
+    byte = (loc >> 8) & 0xFF;
+    outb(byte, 0x3d5);
+}

--- a/kernel/vid.h
+++ b/kernel/vid.h
@@ -1,0 +1,48 @@
+#ifndef VID_H__
+#define VID_H__
+
+#define MAX_ROW 25
+#define MAX_COL 80
+
+/*
+0 black
+1 blue dark
+2 green dark
+3 blue light
+4 red dark
+5 pink
+6 brown light
+7 grey light
+8 dark grey
+9 blue mid
+a green light
+b turquoise
+c red light
+d pink light
+e yellow
+f white
+*/
+#define BLACK 0x0
+#define GREEN 0x2
+#define BROWN 0x6
+#define LRED 0xc
+#define WHITE 0xf
+
+#define BG_FG(bg, fg) ((bg << 4) | (fg))
+
+#define DEFAULT_BG BLACK
+#define DEFAULT_FG GREEN
+
+#define DEFAULT_ATTR    BG_FG(DEFAULT_BG, DEFAULT_FG)
+
+void home();
+void gotoxy(int x, int y);
+void setcursor(int x, int y);
+void setattr(int _attr);
+int getattr();
+void console_init();
+void cls();
+int dputchar(int c);
+void dputs(const char *s);
+
+#endif/*VID_H__*/

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,0 +1,17 @@
+
+TARGET:=test_libc
+
+all: $(TARGET)
+
+check check32: test_libc
+	./test_libc
+
+CFLAGS+=-Wall -Wextra -Werror -g -O0
+CFLAGS+=-I../kernel
+test_libc: test_libc.o libc.o
+	$(CC) -o $@ $^ -I.
+
+clean:
+	$(RM) *.o $(TARGET)
+
+clobber: clean

--- a/libc/expect.h
+++ b/libc/expect.h
@@ -1,0 +1,6 @@
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define EXPECT_EQ(v1, v2, ...) do{if (v1 == v2){printf("[ SUCCESS ]\n");}else{printf("[ FAIL ] ");printf(__VA_ARGS__);printf("\n");exit(1);}}while(0)
+#define EXPECT_STR_EQ(s1, s2) EXPECT_EQ(strcmp(s1, s2), 0, "expected strings s1=[%s] s2=[%s] equal", s1, s2)

--- a/libc/libc.c
+++ b/libc/libc.c
@@ -1,0 +1,184 @@
+#include <stdarg.h>
+
+#define NOALIAS
+#include "libc.h"
+#include "vid.h"        // dputchar, ...
+
+void *mmemset(void *_s, int c, size_t n) {
+    if (_s) {
+    void *s = _s;
+        while (n--) {
+            *(unsigned char *)s++ = (unsigned char)c;
+        }
+    }
+    return _s;
+}
+
+void *mmemcpy(void *dest, const void *src, size_t n) {
+    if (dest && src) {
+    void *d = dest;
+        while (n--) {
+            *(unsigned char *)d++ = *(unsigned char *)src++;
+        }
+    }
+    return dest;
+}
+
+size_t mstrlen(const char *s) {
+    size_t result = 0;
+    if (s)
+    while (*s++) {
+        result++;
+    }
+    return result;
+}
+
+int mstrncmp(const char *s1, const char *s2, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        if (s1[i] > s2[i])
+            return 1;
+        if (s1[i] < s2[i])
+            return -1;
+    }
+    return 0;
+}
+
+enum {
+    FLAG_HASH = 1 << 0,
+    FLAG_ZERO = 1 << 1,
+    FLAG_MINUS = 1 << 2,
+    FLAG_SPACE = 1 << 3,
+    FLAG_PLUS = 1 << 4,
+    FLAG_UPPER = 1 << 5,
+};
+// size: max number of bytes to write to str
+// width: desired number of bytes written
+static int number(char *str, size_t size, unsigned long num, int base, int width, int flags) {
+    size_t written = 0, ofs;
+    int n = 0;
+    if (base == 16) {
+        int upper = flags & FLAG_UPPER;
+        if (flags & FLAG_HASH) {
+            str[written++] = '0';
+            str[written++] = upper ? 'X' : 'x';
+        }
+        for (int v = num; ;) {
+            n++;
+            v = v / base;
+            if (!v) break;
+        }
+        ofs = written;
+        if (width > n) ofs += width - n;
+        for (; n > 0;) {
+            written++;
+            int d = num % base;
+            str[ofs + --n] = d >= 10 ? d + (upper ? 'A' : 'a') - 10 : d + '0';
+            num /= base;
+        }
+    } else {
+        base = 10;
+#if 0
+        if (written < (size - 1) && num < 0) {
+            str[written++] = '-';
+            num = -num;
+        }
+#endif
+        for (int v = num; ;) {
+            n++;
+            v = v / base;
+            if (!v) break;
+        }
+        ofs = written;
+        if (width > n) ofs += width - n;
+        for (; n > 0;) {
+            written++;
+            int d = num % base;
+            str[ofs + --n] = d + '0';
+            num /= base;
+        }
+    }
+    char filler = flags & FLAG_ZERO ? '0' : flags & FLAG_HASH ? 0 : ' ';
+    for (; filler && ofs > 0;) {
+        written++;
+        str[--ofs] = filler;
+    }
+    if (written < size)
+        str[written] = 0;
+    return written;
+}
+
+int mvsnprintf(char *str, size_t size, const char *format, va_list ap) {
+    void *ptr;
+    int chr;
+    int num;
+    size_t written = 0;
+    if (!str || !format) return 0;
+    while (*format && written < (size - 1)) {
+        int width = 0;
+        int flags = 0;
+        if (*format == '%') {
+            while (written < size) {
+                format++;
+                switch (*format) {
+                    case 'l':
+                        continue;
+                    case '0':
+                        flags |= FLAG_ZERO;
+                        continue;
+                    case '#':
+                        flags |= FLAG_HASH;
+                        continue;
+                    case '1'...'9':
+                        width = *format - '0';
+                        continue;
+                    case 'X':
+                        flags |= FLAG_UPPER; /* fallthrough */
+                    case 'p':
+                    case 'x':
+                        if (*format == 'p') flags |= FLAG_HASH;
+                        num = va_arg(ap, typeof(num));
+                        written += number(str + written, size - written, num, 16, width, flags);
+                        break;
+                    case 'c':
+                        chr = va_arg(ap, typeof(chr));
+                        str[written++] = chr;
+                        break;
+                    case 's': {
+                        ptr = va_arg(ap, typeof(ptr));
+                        int len = strlen(ptr);
+                        if (written + len > size) {
+                            len = size - written;
+                        }
+                        memcpy(str + written, ptr, len);
+                        written += len;
+                        break;
+                    }
+                    case 'd':
+                        num = va_arg(ap, typeof(num));
+                        written += number(str + written, size - written, num, 10, width, flags);
+                        break;
+                }
+                break;
+            }
+        }
+        else
+            str[written++] = *format;
+        format++;
+    }
+    if (written < size) {
+        str[written] = 0;
+    }
+    return written;
+}
+
+int mprintf(const char *fmt, ...) {
+    int result;
+    va_list ap;
+    va_start(ap, fmt);
+    static char buf[1024];
+    memset(buf, 'X', sizeof(buf));
+    result = vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    dputs(buf);
+    return result;
+}

--- a/libc/libc.h
+++ b/libc/libc.h
@@ -1,0 +1,27 @@
+#ifndef __LIBC_H__
+#define __LIBC_H__
+
+#ifndef NO_ALIAS
+#include "types.h"
+#endif
+
+#include <stdarg.h>
+
+#ifndef NO_ALIAS
+#define memset mmemset
+#define memcpy mmemcpy
+#define strlen mstrlen
+#define puts dputs
+#define printf mprintf
+#define vsnprintf mvsnprintf
+#define strncmp mstrncmp
+#endif
+
+void *mmemset(void *_s, int c, size_t n);
+void *mmemcpy(void *dest, const void *src, size_t n);
+size_t mstrlen(const char *s);
+int mprintf(const char *fmt, ...) asm ("mprintf");
+int mvsnprintf(char *str, size_t size, const char *fmt, va_list ap) asm ("mvsnprintf");
+int mstrncmp(const char *s1, const char *s2, size_t n);
+
+#endif/*__LIBC_H__*/

--- a/libc/test_libc.c
+++ b/libc/test_libc.c
@@ -1,0 +1,51 @@
+#include <inttypes.h>
+#include <string.h>
+
+#define NO_ALIAS
+#include "libc.h"
+
+#include <stdio.h>
+
+#include "expect.h"
+
+void dputchar(char c) {
+    putchar(c);
+}
+
+void dputs(char *s) {
+    printf("%s", s);fflush(stdout);
+}
+
+void msnprintf(char *str, size_t size, const char *format, ...) {
+    va_list ap;
+    va_start(ap, format);
+    mvsnprintf(str, size, format, ap);
+    va_end(ap);
+}
+
+#if 0
+//#define ARGS "Kernel panic: [toto=%s dead=%" PRIx16 " 0xffff0=%p 0XAC1DC0D3=%#" PRIX32 " 1234=%d]\n", "toto", 0xdead, (void *)0xffff0, 0xac1dc0d3, 1234
+#define ARGS "|%" PRIx16 " ", 0xdead
+#define RES "|dead "
+#else
+#define ARGS "|%d ", 1234
+#define RES "|1234 "
+#endif
+int main() {
+//    printf(ARGS);
+//    mprintf(ARGS);
+
+    char buf[90];
+
+    memset(buf, 'E', sizeof(buf));
+    snprintf(buf, sizeof(buf), ARGS);
+    EXPECT_STR_EQ(buf, RES);
+//    printf("%s", buf);
+
+    memset(buf, 'E', sizeof(buf));
+    msnprintf(buf, sizeof(buf), ARGS);
+    EXPECT_STR_EQ(buf, RES);
+//    printf("%s", buf);
+
+    return 0;
+}

--- a/libc/vid.h
+++ b/libc/vid.h
@@ -1,0 +1,3 @@
+
+void dputchar(char c);
+void dputs(char *s);

--- a/vade/src/task/task.c
+++ b/vade/src/task/task.c
@@ -1,0 +1,5 @@
+#include "task.h"
+
+int task_Mock() {
+    return 42;
+}

--- a/vade/src/task/task.h
+++ b/vade/src/task/task.h
@@ -1,0 +1,6 @@
+#ifndef TASK_H__
+#define TASK_H__
+
+int task_Mock();
+
+#endif/*TASK_H__*/

--- a/vade/src/task/task_test.c
+++ b/vade/src/task/task_test.c
@@ -1,0 +1,105 @@
+#include "task.h"
+#include "test/test.h"
+#if 0
+#include <inttypes.h>
+#pragma pack(1)
+typedef struct {
+    uint32_t gs;
+    uint32_t fs;
+    uint32_t es;
+    uint32_t ds;
+    uint32_t ss;
+    uint16_t filler;
+    uint32_t eax;
+    uint32_t ebx;
+    uint32_t ecx;
+    uint32_t edx;
+    uint32_t esi;
+    uint32_t edi;
+} irq_regs_t;
+
+typedef struct {
+    uint32_t ebp;
+    uint32_t zero;
+    uint32_t eip;
+    uint32_t cs;
+    uint32_t eflags;
+} irq_ctx_t;
+#pragma pack()
+
+static int kbhits = 0;
+
+static int jiffies = 0;
+
+struct task;
+typedef struct task {
+    struct task *next;
+    uint32_t eip;
+    uint32_t cs;
+    uint32_t eflags;
+} task_t;
+static task_t tasks[10] = {0};
+int ntasks = 0;
+static task_t *current = 0;
+
+void disable(){}
+void enable(){}
+
+void create_task(void *ptr) {
+    disable();
+    tasks[ntasks].eip = (uintptr_t)ptr;
+    if (current) tasks[ntasks].next = 0;
+    current = &tasks[ntasks++];
+}
+
+void switch_task() {
+    if (current && current->next && current != current->next) {
+        current->eip = ctx->eip;
+        current->cs = ctx->cs;
+        current->eflags = ctx->eflags;
+        current = current->next;
+    }
+}
+
+static void dummy1() {
+    int y = 1;
+    while (1) {
+        static int count = 0;
+        gotoxy(0, y);
+        printf("%s: jiffies=%d count=%d\n", __func__, jiffies, count++);
+    }
+}
+
+static void dummy2() {
+    int y = 2;
+    while (1) {
+        static int count = 0;
+        gotoxy(0, y);
+        printf("%s: jiffies=%d count=%d\n", __func__, jiffies, count++);
+    }
+}
+
+void schedule() {
+    create_task(dummy1);
+    enable();
+    while (1) {
+        static int count = 0;
+        for (int i = 0; i < jiffies*1+10; i++) {
+        gotoxy(0, 1);
+        printf("hi jiffies=%d count=%d\n", jiffies, count++);
+            asm volatile("hlt");
+        }
+        halt();
+    }
+}
+
+void kernel_main(void) {
+    schedule();
+    gotoxy(0, 1);
+    panic("[toto=%s dead=%" PRIx16 " ffff0=%p ac1dc0d3=%" PRIx32 " 1234=%d]", "toto", 0xdead, 0xffff0, 0xac1dc0d3, 1234);
+}
+#endif
+TEST_F(task, Mock) {
+    TEST_LOG("Testing task..\n");
+    EXPECT_EQ(42, task_Mock());
+}

--- a/x86_64/Makefile
+++ b/x86_64/Makefile
@@ -1,0 +1,58 @@
+TARGET:=kernel64.elf kernel64.bin
+GDB:=gdb
+NASM:=nasm
+
+Q:=qemu-system-x86_64 -cdrom iso64.iso -s
+#DBG:=1
+ifdef DBG
+Q+=-S
+endif
+
+all: kernel64.elf
+
+check64:    kernel64.elf
+	grub-file --is-x86-multiboot kernel64.elf && echo "Success!" || (echo "Fail!!" ; false)
+	mkdir -p isodir/boot/grub
+	cp -f kernel64.elf isodir/boot/
+	echo 'set default="0"' > isodir/boot/grub/grub.cfg
+	echo 'set timeout=1' >> isodir/boot/grub/grub.cfg
+	echo 'menuentry "kernel64 elf" {' >> isodir/boot/grub/grub.cfg
+	echo 'multiboot /boot/kernel64.elf' >> isodir/boot/grub/grub.cfg
+	echo '}' >> isodir/boot/grub/grub.cfg
+	grub-mkrescue -o iso64.iso isodir
+	$(Q)
+
+iso64: check64
+
+kernel64.elf: boot.o kernel.o libc.o vid.o gdt.o panic.o idt.o
+	gcc -m64 -T linker.ld -o kernel64.elf -ffreestanding -g -O0 $^ -nostdlib -lgcc
+
+db64:
+#	$(MAKE) check64 T=1 &
+	$(GDB) -ex 'set confirm off' -ex 'target remote :1234' -ex 'disp/i$$cs*16+(unsigned short)$$rip' -ex 'disp/8bx$$cs*16+(unsigned short)$$rip' -ex 'disp/x$$rax' -ex 'disp/x$$rbx' -ex 'disp/x$$cs' -ex 'disp/x$$rip' -ex 'file src/kernel64/kernel64.elf' -ex 'b kernel_main'
+
+CFLAGS:=-m64 -std=gnu99
+CFLAGS+=-ffreestanding -z max-page-size=0x1000 -mno-red-zone -mno-mmx -mno-sse -mno-sse2
+CFLAGS+=-g -O0 -Wall -Wextra -Werror -I../libc -I../kernel
+%.o: ../libc/%.c
+	gcc -c $< -o $@ $(CFLAGS)
+
+%.o: ../kernel/%.c
+	gcc -c $< -o $@ $(CFLAGS)
+
+%.o:    %.asm
+	$(NASM) -f elf -o $@ $<
+
+%.o:    %.S
+	gcc -m64 -c $< -o $@ $(CFLAGS) -DASSEMBLY
+
+%.bin: %.elf
+	objcopy --remove-section=.note.gnu.build-id -O binary $^ $@
+
+all: $(TARGET)
+
+clean:
+	$(RM) $(TARGET) *.o *.iso
+
+clobber: clean
+	$(RM) -Rf isodir

--- a/x86_64/boot.S
+++ b/x86_64/boot.S
@@ -1,0 +1,129 @@
+.code64
+/* Declare constants for the multiboot header. */
+.set ALIGN,    1<<0             /* align loaded modules on page boundaries */
+.set MEMINFO,  1<<1             /* provide memory map */
+.set FLAGS,    ALIGN | MEMINFO  /* this is the Multiboot 'flag' field */
+.set MAGIC,    0x1BADB002       /* 'magic number' lets bootloader find the header */
+.set CHECKSUM, -(MAGIC + FLAGS) /* checksum of above, to prove we are multiboot */
+ 
+/* 
+Declare a multiboot header that marks the program as a kernel. These are magic
+values that are documented in the multiboot standard. The bootloader will
+search for this signature in the first 8 KiB of the kernel file, aligned at a
+32-bit boundary. The signature is in its own section so the header can be
+forced to be within the first 8 KiB of the kernel file.
+*/
+.section .multiboot
+.align 4
+.long MAGIC
+.long FLAGS
+.long CHECKSUM
+ 
+/*
+The multiboot standard does not define the value of the stack pointer register
+(esp) and it is up to the kernel to provide a stack. This allocates room for a
+small stack by creating a symbol at the bottom of it, then allocating 16384
+bytes for it, and finally creating a symbol at the top. The stack grows
+downwards on x86. The stack is in its own section so it can be marked nobits,
+which means the kernel file is smaller because it does not contain an
+uninitialized stack. The stack on x86 must be 16-byte aligned according to the
+System V ABI standard and de-facto extensions. The compiler will assume the
+stack is properly aligned and failure to align the stack will result in
+undefined behavior.
+*/
+
+.section .bss
+.global stack_bottom
+.global stack_top
+.align 16
+stack_bottom:
+.skip 16384 # 16 KiB
+stack_top:
+
+/*
+The linker script specifies _start as the entry point to the kernel and the
+bootloader will jump to this position once the kernel has been loaded. It
+doesn't make sense to return from this function as the bootloader is gone.
+*/
+.section .text
+.global _start
+.global gdt
+.type _start, @function
+_start:
+    /*
+    The bootloader has loaded us into 32-bit protected mode on a x86
+    machine. Interrupts are disabled. Paging is disabled. The processor
+    state is as defined in the multiboot standard. The kernel has full
+    control of the CPU. The kernel can only make use of hardware features
+    and any code it provides as part of itself. There's no printf
+    function, unless the kernel provides its own <stdio.h> header and a
+    printf implementation. There are no security restrictions, no
+    safeguards, no debugging mechanisms, only what the kernel provides
+    itself. It has absolute and complete power over the
+    machine.
+    */
+ 
+    /*
+    To set up a stack, we set the esp register to point to the top of the
+    stack (as it grows downwards on x86 systems). This is necessarily done
+    in assembly as languages such as C cannot function without a stack.
+    */
+/*    mov $stack_top, %rsp*/
+ 
+    /*
+    This is a good place to initialize crucial processor state before the
+    high-level kernel is entered. It's best to minimize the early
+    environment where crucial features are offline. Note that the
+    processor is not fully initialized yet: Features such as floating
+    point instructions and instruction set extensions are not initialized
+    yet. The GDT should be loaded here. Paging should be enabled here.
+    C++ features such as global constructors and exceptions will require
+    runtime support to work as well.
+    */
+/*    sgdt gdt*/
+
+    /*
+    Enter the high-level kernel. The ABI requires the stack is 16-byte
+    aligned at the time of the call instruction (which afterwards pushes
+    the return pointer of size 4 bytes). The stack was originally 16-byte
+    aligned above and we've pushed a multiple of 16 bytes to the
+    stack since (pushed 0 bytes so far), so the alignment has thus been
+    preserved and the call is well defined.
+    */
+    call kernel_main
+ 
+    /*
+    If the system has nothing more to do, put the computer into an
+    infinite loop. To do that:
+    1) Disable interrupts with cli (clear interrupt enable in eflags).
+       They are already disabled by the bootloader, so this is not needed.
+       Mind that you might later enable interrupts and return from
+       kernel_main (which is sort of nonsensical to do).
+    2) Wait for the next interrupt to arrive with hlt (halt instruction).
+       Since they are disabled, this will lock up the computer.
+    3) Jump to the hlt instruction if it ever wakes up due to a
+       non-maskable interrupt occurring or due to system management mode.
+    */
+    cli
+1:      hlt
+    jmp 1b
+/*
+gdt:
+NULL_Desc:
+.word EndGDT-gdt-1
+//.long gdt+KERNEL_ADDR
+.long gdt
+.word 0
+CS_Desc:
+.word 0xFFFF,0
+.byte 0,0x9B,0xCF,0
+DS_Desc:
+.word 0xFFFF,0
+.byte 0,0x93,0xCF,0
+EndGDT:
+*/
+/*
+Set the size of the _start symbol to the current location '.' minus its start.
+This is useful when debugging or when you implement call tracing.
+*/
+.size _start, . - _start

--- a/x86_64/idt_wrappers.S
+++ b/x86_64/idt_wrappers.S
@@ -1,0 +1,133 @@
+#include "idt.h"
+
+.code64
+
+.extern idt_handlers
+.globl idt_wrappers
+.globl def_int_wrappers
+
+/* wrapper for exceptions without error code */
+.irp id,0,1,2,3,4,5,6,7,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33
+.p2align 2,0x90
+exc_wrapper_\id:
+cld
+push %rax
+push %rcx
+push %rdx
+push %rsi
+push %rdi
+push %r8
+push %r9
+push %r10
+push %r11
+lea idt_handlers,%rax
+mov %rbp,%rsi
+mov $\id,%rdi
+// abi64: rdi rsi rdx rcx r8 r9
+call *\id*8(%rax)
+mov $0x20,%al
+outb %al,$0x20
+pop %r11
+pop %r10
+pop %r9
+pop %r8
+pop %rdi
+pop %rsi
+pop %rdx
+pop %rcx
+pop %rax
+iretq
+.endr
+
+/* wrapper for exceptions with error code */
+.irp id,8
+.p2align 2,0x90
+exc_wrapper_\id:
+movw $0x0c41,0xb8000
+1:
+hlt
+jmp 1b
+.endr
+
+/* wrapper irqs without error code */
+.irp id,IRQ_TIMER,IRQ_KB
+.p2align 2,0x90
+irq_wrapper_\id:
+movw $0x0c42,0xb8000
+1:
+hlt
+jmp 1b
+.endr
+
+#if 0
+dblflt_stack0:
+.string "EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"
+dblflt_stack:
+msg:
+.string "DBLFLT@%p:%p %p"
+
+.irp id,EXCEPTION_DOUBLE
+.p2align 2,0x90
+exc_wrapper_\id:
+// print double fault message before infinite loop
+movw $0x0c43,0xb8000
+1:
+hlt
+jmp 1b
+.endr
+#endif
+
+/*
+Present on stack at entry: rip+ cs rflags rsp ss
+*/
+def_int_stack0:
+.string "EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"
+def_int_stack:
+def_int_msg:
+.string "int #%x : esp=%p : %p %p %p %p %p"
+.irp id,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33
+.p2align 2,0x90
+def_int_wrapper_\id:
+mov %rsp,%rbp
+mov $def_int_stack,%rsp
+push 8*4(%rbp)
+push 8*3(%rbp)
+push 8*2(%rbp)
+push 8*1(%rbp)
+push (%rbp)
+push %rbp
+push $\id
+push $def_int_msg
+mov $0x0C,%rdi
+call setattr
+call home
+pop %rdi
+pop %rsi
+pop %rdx
+pop %rcx
+pop %r8
+pop %r9
+call mprintf
+1:
+hlt
+jmp 1b
+.endr
+argh:
+.string "ARGH def_int_wrapper_%p: %p %p %p"
+
+.section .rodata
+.p2align 5,0x0
+idt_wrappers:
+.irp id,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33
+.quad exc_wrapper_\id
+.endr
+
+irq_wrappers:
+.irp id,0,1
+.quad irq_wrapper_\id
+.endr
+
+def_int_wrappers:
+.irp id,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33
+.quad def_int_wrapper_\id
+.endr

--- a/x86_64/linker.ld
+++ b/x86_64/linker.ld
@@ -1,0 +1,44 @@
+/* The bootloader will look at this image and start execution at the symbol
+   designated as the entry point. */
+ENTRY(_start)
+ 
+/* Tell where the various sections of the object files will be put in the final
+   kernel image. */
+SECTIONS
+{
+    /* Begin putting sections at 1 MiB, a conventional place for kernels to be
+       loaded at by the bootloader. */
+/*    . = 0x7e00;*/
+    . = 0x10000;
+
+    /* First put the multiboot header, as it is required to be put very early
+       early in the image or the bootloader won't recognize the file format.
+       Next we'll put the .text section. */
+    .text BLOCK(4K) : ALIGN(4K)
+    {
+        *(.multiboot)
+        *(.text)
+    }
+
+    /* Read-only data. */
+    .rodata BLOCK(4K) : ALIGN(4K)
+    {
+        *(.rodata)
+    }
+
+    /* Read-write data (initialized) */
+    .data BLOCK(4K) : ALIGN(4K)
+    {
+        *(.data)
+    }
+
+    /* Read-write data (uninitialized) and stack */
+    .bss BLOCK(4K) : ALIGN(4K)
+    {
+        *(COMMON)
+        *(.bss)
+    }
+
+    /* The compiler may produce other sections, by default it will put them in
+       a segment with the same name. Simply add stuff here as needed. */
+}


### PR DESCRIPTION
This is a pretty basic IA32 kernel, inspired on high-level parts of https://github.com/nsauzede/myos
but with lower-level rewritten from scratch, based on osdev.org documentation.
Basically, this kernel can boot from GRUB to 32-bit protected mode.
Timer and keyboard interrupts handled.
The idea is to then develop more features using https://github.com/nsauzede/ns_vade TDD methodology.
